### PR TITLE
Fix LanguageAdapterException

### DIFF
--- a/platform-fabric-1.14/src/main/resources/fabric.mod.json
+++ b/platform-fabric-1.14/src/main/resources/fabric.mod.json
@@ -18,7 +18,7 @@
 
   "environment": "client",
   "entrypoints": {
-    "main": [ "com.unascribed.ears.EarsMod" ],
+    "client": [ "com.unascribed.ears.EarsMod" ],
     "modmenu": [ "com.unascribed.ears.EarsModMenu" ]
   },
   "mixins": [

--- a/platform-fabric-1.16/src/main/resources/fabric.mod.json
+++ b/platform-fabric-1.16/src/main/resources/fabric.mod.json
@@ -18,7 +18,7 @@
 
   "environment": "client",
   "entrypoints": {
-    "main": [ "com.unascribed.ears.EarsMod" ],
+    "client": [ "com.unascribed.ears.EarsMod" ],
     "modmenu": [ "com.unascribed.ears.EarsModMenu" ]
   },
   "mixins": [

--- a/platform-fabric-1.17/src/main/resources/fabric.mod.json
+++ b/platform-fabric-1.17/src/main/resources/fabric.mod.json
@@ -18,7 +18,7 @@
 
   "environment": "client",
   "entrypoints": {
-    "main": [ "com.unascribed.ears.EarsMod" ],
+    "client": [ "com.unascribed.ears.EarsMod" ],
     "modmenu": [ "com.unascribed.ears.EarsModMenu" ]
   },
   "mixins": [

--- a/platform-fabric-1.19/src/main/resources/fabric.mod.json
+++ b/platform-fabric-1.19/src/main/resources/fabric.mod.json
@@ -18,7 +18,7 @@
 
   "environment": "client",
   "entrypoints": {
-    "main": [ "com.unascribed.ears.EarsMod" ],
+    "client": [ "com.unascribed.ears.EarsMod" ],
     "modmenu": [ "com.unascribed.ears.EarsModMenu" ]
   },
   "mixins": [

--- a/platform-fabric-b1.7.3/src/main/resources/fabric.mod.json
+++ b/platform-fabric-b1.7.3/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
 
   "environment": "client",
   "entrypoints": {
-    "main": [ "com.unascribed.ears.EarsMod" ],
+    "client": [ "com.unascribed.ears.EarsMod" ],
     "modmenu": [ "com.unascribed.ears.EarsModMenu" ]
   },
   "mixins": ["ears.mixins.json"],


### PR DESCRIPTION
Fixes the following launch exception on Fabric.

```
Caused by: net.fabricmc.loader.api.LanguageAdapterException: Class com.unascribed.ears.EarsMod cannot be cast to net.fabricmc.api.ModInitializer!
```