### PR TITLE
Clear files after upload

### DIFF
--- a/manipulator/index.html
+++ b/manipulator/index.html
@@ -916,6 +916,7 @@ SOFTWARE.
 			}
 			await rebuild();
 		} finally {
+			$("#skin-upload").value = null;
 			document.body.classList.remove("loading");
 		}
 	}
@@ -986,6 +987,7 @@ SOFTWARE.
 			encodeToAlfalfa("wing", "#wings");
 			await rebuild();
 		} finally {
+			$("#wing-upload").value = null;
 			document.body.classList.remove("loading");
 		}
 	}
@@ -1014,6 +1016,7 @@ SOFTWARE.
 			encodeToAlfalfa("cape", "#cape");
 			await rebuild();
 		} finally {
+			$("#cape-upload").value = null;
 			document.body.classList.remove("loading");
 		}
 	}


### PR DESCRIPTION
Thanks for the cool mod!

I was playing with the manipulator for a bit; one thing that I found inconvenient was that every time I re-exported a file from my image editing software and uploaded it again, it wouldn't update because the same file path was already present in the file picker. Setting the value of the file picker back to `null` afterwards instead allows it to be directly re-uploaded. This PR applies that change to all (:smile:) of the upload buttons.