### PR TITLE
Load player skins in Manipulator from URL parameters

### DIFF
--- a/common/src/main/java/com/unascribed/ears/common/EarsCommon.java
+++ b/common/src/main/java/com/unascribed/ears/common/EarsCommon.java
@@ -102,7 +102,7 @@ public class EarsCommon {
 	}
 	
 	public static String getConfigUrl(String username, String uuid) {
-		return "https://ears.unascribed.com/manipulator/?v="+EarsVersion.COMMON+(uuid == null ? "&username="+username : "&id="+uuid);
+		return "https://ears.unascribed.com/manipulator/#v="+EarsVersion.COMMON+(uuid == null ? ",username="+username : ",id="+uuid);
 	}
 	
 	public static AlfalfaData preprocessSkin(WritableEarsImage img) {

--- a/common/src/main/java/com/unascribed/ears/common/EarsCommon.java
+++ b/common/src/main/java/com/unascribed/ears/common/EarsCommon.java
@@ -102,7 +102,7 @@ public class EarsCommon {
 	}
 	
 	public static String getConfigUrl(String username, String uuid) {
-		return "https://ears.unascribed.com/manipulator/#v="+EarsVersion.COMMON+(uuid == null ? ",username="+username : ",id="+uuid);
+		return "https://ears.unascribed.com/manipulator/?v="+EarsVersion.COMMON+(uuid == null ? "&username="+username : "&id="+uuid);
 	}
 	
 	public static AlfalfaData preprocessSkin(WritableEarsImage img) {

--- a/manipulator/index.html
+++ b/manipulator/index.html
@@ -919,30 +919,32 @@ SOFTWARE.
 			document.body.classList.remove("loading");
 		}
 	}
-	async function getSkinFromParams() {
+	async function getSkinFromHash() {
 		let input = $("#skin-upload");
-		let params = new URLSearchParams(window.location.search);
-		if (input.files.length > 0 || !params.has("username") && !params.has("id")) return;
-		let id = (params.has("id") ? params.get("id") : null);
-		if (!id && params.has("username")) {
-			try { 
-				await fetch("https://mc-heads.net/minecraft/profile/" + params.get("username"))
+		let hash = window.location.hash.slice(1);
+		let params = hash.split(',').reduce((params, param) => {
+				let [key, value] = param.split('=');
+				return Object.assign(params, { [key]: value });
+			}, {});
+		if (input.files.length > 0 || !params["username"] && !params["id"]) return;
+		let id = (params["id"] || null);
+		if (!id && params["username"]) {
+			try {
+				await fetch("https://playerdb.co/api/player/minecraft/" + params["username"])
 					.then(res => res.json())
 					.then(json => {
-						id = json.id;
+						if (json.success === false) throw new Error("Failed to fetch player data from playerdb.co");
+						id = json.data.player.id;
 					});
 			} catch (e) {
 				console.error(e);
 				return;
 			}
 		}
-		let skinUrl = "https://crafatar.com/skins/" + id;
+		let skinUrl = "https://visage.surgeplay.com/skin/" + id;
 		try {
 			let res = await fetch(skinUrl);
-			if (!res.ok) {
-				console.error("Failed to fetch skin from " + skinUrl);
-				return
-			}
+			if (!res.ok) throw new Error("Failed to fetch skin from " + skinUrl);
 			let blob = await res.blob();
 			let file = new File([blob], "skin.png");
 			let dataTransfer = new DataTransfer();
@@ -1356,7 +1358,7 @@ SOFTWARE.
 	window.addEventListener("resize", () => updateDpr());
 	updateDpr();
 	updateSkin();
-	getSkinFromParams();
+	getSkinFromHash();
 
 	if (WEBGL.isWebGLAvailable()) {
 		let scene = new THREE.Scene();

--- a/manipulator/index.html
+++ b/manipulator/index.html
@@ -919,6 +919,42 @@ SOFTWARE.
 			document.body.classList.remove("loading");
 		}
 	}
+	async function getSkinFromParams() {
+		let input = $("#skin-upload");
+		let params = new URLSearchParams(window.location.search);
+		if (input.files.length > 0 || !params.has("username") && !params.has("id")) return;
+		let id = (params.has("id") ? params.get("id") : null);
+		if (!id && params.has("username")) {
+			try { 
+				await fetch("https://mc-heads.net/minecraft/profile/" + params.get("username"))
+					.then(res => res.json())
+					.then(json => {
+						id = json.id;
+					});
+			} catch (e) {
+				console.error(e);
+				return;
+			}
+		}
+		let skinUrl = "https://crafatar.com/skins/" + id;
+		try {
+			let res = await fetch(skinUrl);
+			if (!res.ok) {
+				console.error("Failed to fetch skin from " + skinUrl);
+				return
+			}
+			let blob = await res.blob();
+			let file = new File([blob], "skin.png");
+			let dataTransfer = new DataTransfer();
+			dataTransfer.items.add(file);
+			input.files = dataTransfer.files;
+			updateSkin();
+		}
+		catch (e) {
+			console.error(e);
+			return;
+		}
+	}
 	function copyFromAlfalfa(id, sel) {
 		return new Promise((resolve, reject) => {
 				let img = new Image();
@@ -1320,6 +1356,7 @@ SOFTWARE.
 	window.addEventListener("resize", () => updateDpr());
 	updateDpr();
 	updateSkin();
+	getSkinFromParams();
 
 	if (WEBGL.isWebGLAvailable()) {
 		let scene = new THREE.Scene();


### PR DESCRIPTION
Hopefully closes #106 
This requires an external API, because the official one doesn't allow AJAX requests. The page could receive a UUID or username, so it also must convert a username into a UUID. Unfortunately, mc-heads.net doesn't return the correct skin (the alpha channel gets all messed up), so another API was required (crafatar.com doesn't allow one to convert from username to UUID).
![chrome_fCtP9YSE1r](https://user-images.githubusercontent.com/78718829/213897672-a9df2acf-4160-434d-9578-f9b9ec36e8a3.gif)
I would suggest finding another API provider, but beyond that the PR is functional.