### PR TITLE
[stapi-b1.7.3] disable skinfix when RetroAuth is loaded

### DIFF
--- a/platform-stapi-b1.7.3/src/main/java/com/unascribed/ears/mixin/EarsMixinPlugin.java
+++ b/platform-stapi-b1.7.3/src/main/java/com/unascribed/ears/mixin/EarsMixinPlugin.java
@@ -17,6 +17,7 @@ public class EarsMixinPlugin implements IMixinConfigPlugin {
     public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
         boolean isMojFixInstalled = FabricLoader.getInstance().isModLoaded("mojangfixstationapi");
         boolean isCPMInstalled = FabricLoader.getInstance().isModLoaded("cpm");
+        boolean isRetroAuthInstalled = FabricLoader.getInstance().isModLoaded("retroauth");
 
         if (mixinClassName.startsWith("com.unascribed.ears.mixin.skinfix")) {
             if (isMojFixInstalled) {
@@ -24,6 +25,9 @@ public class EarsMixinPlugin implements IMixinConfigPlugin {
             }
             if (isCPMInstalled) {
                 EarsLog.debug(EarsLog.Tag.PLATFORM_LOAD, "Customizable Player Models is installed, disabling Ears skinfix.");
+            }
+            if (isRetroAuthInstalled) {
+                EarsLog.debug(EarsLog.Tag.PLATFORM_LOAD, "RetroAuth is installed, disabling Ears skinfix.");
             }
             return !(isMojFixInstalled || isCPMInstalled);
         }

--- a/platform-stapi-b1.7.3/src/main/java/com/unascribed/ears/mixin/EarsMixinPlugin.java
+++ b/platform-stapi-b1.7.3/src/main/java/com/unascribed/ears/mixin/EarsMixinPlugin.java
@@ -29,7 +29,7 @@ public class EarsMixinPlugin implements IMixinConfigPlugin {
             if (isRetroAuthInstalled) {
                 EarsLog.debug(EarsLog.Tag.PLATFORM_LOAD, "RetroAuth is installed, disabling Ears skinfix.");
             }
-            return !(isMojFixInstalled || isCPMInstalled);
+            return !(isMojFixInstalled || isCPMInstalled || isRetroAuthInstalled);
         }
 
         return true;


### PR DESCRIPTION
Currently, if the StationAPI version is run with RetroAuth (kind of a replacement for MojangFix), it is still applying the skinfix mixins, which causes RetroAuth to fail to load. This PR adds one more check to the MixinPlugin to disable the skinfix mixins if RetroAuth is loaded. 