### PR TITLE
Fix arm rendering on NeoForge 1.21.10 and 1.21.11.

### DIFF
--- a/platform-neoforge-1.21.10/src/main/java/com/unascribed/ears/mixin/MixinPlayerRenderer.java
+++ b/platform-neoforge-1.21.10/src/main/java/com/unascribed/ears/mixin/MixinPlayerRenderer.java
@@ -35,13 +35,13 @@ public abstract class MixinPlayerRenderer<AvatarlikeEntity extends Avatar & Clie
 		this.addLayer(ears$layerRenderer = new EarsLayerRenderer((AvatarRenderer)(Object)this));
 	}
 
-	@Inject(at = @At("TAIL"), method = "renderLeftHand(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;ILnet/minecraft/resources/ResourceLocation;Z)V")
-	private void renderLeftArm(PoseStack ms, SubmitNodeCollector vcp, int light, ResourceLocation skinTexture, boolean sleeveVisible, CallbackInfo ci) {
+	@Inject(at = @At("TAIL"), method = "renderLeftHand(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;ILnet/minecraft/resources/ResourceLocation;ZLnet/minecraft/client/player/AbstractClientPlayer;)V")
+	private void renderLeftArm(PoseStack ms, SubmitNodeCollector vcp, int light, ResourceLocation skinTexture, boolean sleeveVisible, AbstractClientPlayer player, CallbackInfo ci) {
 		ears$layerRenderer.renderLeftArm(ms, vcp, light);
 	}
 	
-	@Inject(at = @At("TAIL"), method = "renderRightHand(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;ILnet/minecraft/resources/ResourceLocation;Z)V")
-	private void renderRightArm(PoseStack ms, SubmitNodeCollector vcp, int light, ResourceLocation skinTexture, boolean sleeveVisible, CallbackInfo ci) {
+	@Inject(at = @At("TAIL"), method = "renderRightHand(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;ILnet/minecraft/resources/ResourceLocation;ZLnet/minecraft/client/player/AbstractClientPlayer;)V")
+	private void renderRightArm(PoseStack ms, SubmitNodeCollector vcp, int light, ResourceLocation skinTexture, boolean sleeveVisible, AbstractClientPlayer player, CallbackInfo ci) {
 		ears$layerRenderer.renderRightArm(ms, vcp, light);
 	}
 

--- a/platform-neoforge-1.21.11/src/main/java/com/unascribed/ears/mixin/MixinAvatarRenderer.java
+++ b/platform-neoforge-1.21.11/src/main/java/com/unascribed/ears/mixin/MixinAvatarRenderer.java
@@ -35,13 +35,13 @@ public abstract class MixinAvatarRenderer<AvatarlikeEntity extends Avatar & Clie
 		this.addLayer(ears$layerRenderer = new EarsLayerRenderer((AvatarRenderer)(Object)this));
 	}
 
-	@Inject(at = @At("TAIL"), method = "renderLeftHand(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;ILnet/minecraft/resources/Identifier;Z)V")
-	private void renderLeftArm(PoseStack ms, SubmitNodeCollector vcp, int light, Identifier skinTexture, boolean sleeveVisible, CallbackInfo ci) {
+	@Inject(at = @At("TAIL"), method = "renderLeftHand(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;ILnet/minecraft/resources/Identifier;ZLnet/minecraft/client/player/AbstractClientPlayer;)V")
+	private void renderLeftArm(PoseStack ms, SubmitNodeCollector vcp, int light, Identifier skinTexture, boolean sleeveVisible, AbstractClientPlayer player, CallbackInfo ci) {
 		ears$layerRenderer.renderLeftArm(ms, vcp, light);
 	}
 	
-	@Inject(at = @At("TAIL"), method = "renderRightHand(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;ILnet/minecraft/resources/Identifier;Z)V")
-	private void renderRightArm(PoseStack ms, SubmitNodeCollector vcp, int light, Identifier skinTexture, boolean sleeveVisible, CallbackInfo ci) {
+	@Inject(at = @At("TAIL"), method = "renderRightHand(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;ILnet/minecraft/resources/Identifier;ZLnet/minecraft/client/player/AbstractClientPlayer;)V")
+	private void renderRightArm(PoseStack ms, SubmitNodeCollector vcp, int light, Identifier skinTexture, boolean sleeveVisible, AbstractClientPlayer player, CallbackInfo ci) {
 		ears$layerRenderer.renderRightArm(ms, vcp, light);
 	}
 


### PR DESCRIPTION
Here is the aforementioned PR. I've tested it in the dev environment of the mod I had the mixin in (but without the mixin, of course) and it works fine. (I'd test it elsewhere, but I don't have any other means of testing a skin *without* uploading it to the skin servers.)

(Side note: setting up the Ears dev environment was surprisingly non-trivial, mostly because `common` fails to build if you're not using Java 8. I assume this is already known, but I figured I'd mention it.)

Closes #225.