### PR TITLE
Use strict equality in code

### DIFF
--- a/publish-curseforge/gen-description.js
+++ b/publish-curseforge/gen-description.js
@@ -22,7 +22,7 @@ request({
 		let platforms = {};
 		fs.readdirSync('../').forEach((f) => {
 			let basename = path.basename(f);
-			if (basename.indexOf("platform-") == 0) {
+			if (basename.indexOf("platform-") === 0) {
 				let name = basename.substring(9);
 				let cleaned = name.replace(/-/g, '_').replace(/\./g, '');
 				platforms[name] = cleaned;


### PR DESCRIPTION
Not sure how often code hits the edge case, but The loose equality here can coerce values in ways that are hard to spot later. this patch tightens it to strict equality. Close this if it’s not worth the noise.

Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.